### PR TITLE
pull in html versions of example 1 & related JSON

### DIFF
--- a/LRexample01a.json-ld
+++ b/LRexample01a.json-ld
@@ -1,0 +1,76 @@
+{
+  "@context": {
+    "schema": "http://schema.org/"
+  },
+  "@type": "schema:CreativeWork",
+  "schema:datePublished": "October 4, 2006",
+  "schema:description": "In this activity, students will engage in active problem solving as they create a design for a map leading to a hidden treasure. They will work in collaborative groups, explore numerical problems, and explain the strategies they used to solve design problems.",
+  "schema:educationalAlignment": [
+    {
+      "@type": "schema:AlignmentObject",
+      "schema:alignmentType": "Educational level",
+      "schema:educationalFramework": "US Grade Levels",
+      "schema:targetName": "PreK"
+    },
+    {
+      "@type": "schema:AlignmentObject",
+      "schema:alignmentType": "Educational level",
+      "schema:educationalFramework": "US Grade Levels",
+      "schema:targetName": "1"
+    },
+    {
+      "@type": "schema:AlignmentObject",
+      "schema:alignmentType": "teaches",
+      "schema:educationalFramework": "Common Core State Standards",
+      "schema:targetDescription": "Follow agreed-upon rules for discussions (e.g., listening to others and taking turns speaking about the topics and texts under discussion).",
+      "schema:targetName": "CCSS.ELA-Literacy.SL.K.1a",
+      "schema:targetUrl": [
+        {
+          "@id": "http://purl.org/ASN/resources/S11438E2"
+        },
+        {
+          "@id": "http://www.corestandards.org/ELA-Literacy/SL/K/1/a/"
+        }
+      ]
+    },
+    {
+      "@type": "schema:AlignmentObject",
+      "schema:alignmentType": "teaches",
+      "schema:educationalFramework": "Common Core State Standards",
+      "schema:targetDescription": "Continue a conversation through multiple exchanges.",
+      "schema:targetName": "CCSS.ELA-Literacy.SL.K.1b",
+      "schema:targetUrl": [
+        {
+          "@id": "http://purl.org/ASN/resources/S11438E3"
+        },
+        {
+          "@id": "http://www.corestandards.org/ELA-Literacy/SL/K/1/b/"
+        }
+      ]
+    },
+    {
+      "@type": "schema:AlignmentObject",
+      "schema:alignmentType": "teaches",
+      "schema:educationalFramework": "Common Core State Standards",
+      "schema:targetDescription": "Confirm understanding of a text read aloud or information presented orally or through other media by asking and answering questions about key details and requesting clarification if something is not understood.",
+      "schema:targetName": "CCSS.ELA-Literacy.SL.K.2",
+      "schema:targetUrl": [
+        {
+          "@id": "http://purl.org/ASN/resources/S11438CF"
+        },
+        {
+          "@id": "http://www.corestandards.org/ELA-Literacy/SL/K/2/"
+        }
+      ]
+    }
+  ],
+  "schema:name": "Tiles, Blocks, Sapphires & Gold: Designing a Treasure Map",
+  "schema:publisher": "Cooper-Hewitt National Design Museum",
+  "schema:timeRequired": [
+    "PT2H",
+    "PT1H"
+  ],
+  "schema:url": {
+    "@id": "http://dx.cooperhewitt.org/lessonplan/Tiles-Blocks-Sapphires-Gold-Designing-a-Treasure-Map/"
+  }
+}

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -68,3 +68,4 @@
            
 </div>
 </body>
+</html>

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -5,7 +5,7 @@
 <body>
 <!--html with schema.org / LRMI mark-up as microdata.--> 
 
-<div itemscope itemtype="http://schema.org/CreatineWork">
+<div itemscope itemtype="http://schema.org/CreativeWork">
     <h1 itemprop="name">Tiles, Blocks, Sapphires &amp; Gold: Designing a Treasure Map</h1>
     <p>By <span itemprop="publisher">Cooper-Hewitt National Design Museum</span>, 
         <span itemprop="datePublished">October 4, 2006</span></p>

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -5,7 +5,7 @@
 <body>
 <!--html with schema.org / LRMI mark-up as microdata.--> 
 
-<div itemscope itemtype="http://schema.org/CreativeWork">
+<div itemscope itemtype="http://schema.org/CreatineWork">
     <h1 itemprop="name">Tiles, Blocks, Sapphires &amp; Gold: Designing a Treasure Map</h1>
     <p>By <span itemprop="publisher">Cooper-Hewitt National Design Museum</span>, 
         <span itemprop="datePublished">October 4, 2006</span></p>

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -1,0 +1,70 @@
+<html>
+<head>
+    <title>LRMI Example 01</title>
+</head>
+<body>
+<!--html with no schema.org / LRMI mark-up.--> 
+
+<div itemscope itemtype="http://schema.org/CreativeWork">
+    <h1 itemprop="name">Tiles, Blocks, Sapphires &amp; Gold: Designing a Treasure Map</h1>
+    <p>By <span itemprop="publisher">Cooper-Hewitt National Design Museum</span>, 
+        <span itemprop="datePublished">October 4, 2006</span></p>
+    <h3>Introduction</h3>
+    <p itemprop="description">In this activity, students will engage in active problem solving as they create a design for a map leading to a hidden treasure. They will work in collaborative groups, explore numerical problems, and explain the strategies they used to solve design problems.</p>
+
+    <p>This example description is based on <a itemprop="url" href="Based on http://dx.cooperhewitt.org/lessonplan/Tiles-Blocks-Sapphires-Gold-Designing-a-Treasure-Map/" >this page</a></p>
+ 
+	   <div itemprop="educationalAlignment" itemscope itemtype="http://schema.org/AlignmentObject">
+	       <meta itemprop="alignmentType" content="Educational level" />
+	       <h3 itemprop="educationalFramework">US Grade Levels</h3>
+	       <p><span itemprop="targetName">PreK-1</span></p>
+	   </div>
+	   <div class='catfield'>
+	       <h3>Category</h3>
+	       <ul><li>Graphic Design</li>
+	       </ul>
+	   </div>
+	   <div class='catfield'>
+	       <h3>Subject Area</h3>
+	       <ul><li>Arts</li>
+	           <li>Language Arts</li>
+	           <li>Mathematics</li>
+	       </ul>
+	   </div>
+        
+        <h3>Lesson Time</h3>
+        <p><meta itemprop="timeRequired" content="PT1H" />
+           <meta itemprop="timeRequired" content="PT2H" />
+           One or two fifty-minute class periods
+        </p>
+        
+        <h3>National Standards</h3>
+			 <p>This resource can be used to teach the following skills:</p>
+			 <h4>English Language Arts</h4>
+			 <ul>
+			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
+			     <meta itemprop="alignmentType" content="teaches" />
+			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/1/a/"><span itemprop="educationalFramework">Common Core State Standards</span></a>:
+			     <span itemprop="targetName">CCSS.ELA-Literacy.SL.K.1a</span><br />
+			     <span itemprop="targetDescription">Follow agreed-upon rules for discussions (e.g., listening to others and taking turns speaking about the topics and texts under discussion).</span>
+			     
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E2">
+			  </li>
+			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
+			     <meta itemprop="alignmentType" content="teaches" />
+			     <span itemprop="educationalFramework">Common Core State Standards</span>:
+			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/1/b/"><span itemprop="targetName">CCSS.ELA-Literacy.SL.K.1b</span></a> <br />
+			     <span itemprop="targetDescription">Continue a conversation through multiple exchanges.</span>			     
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E3">
+			  </li>
+			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
+			     <meta itemprop="alignmentType" content="teaches" />
+			     <span itemprop="educationalFramework">Common Core State Standards</span>:
+			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/2/"><span itemprop="targetName">CCSS.ELA-Literacy.SL.K.2</span></a> <br />
+			     <span itemprop="targetDescription">Confirm understanding of a text read aloud or information presented orally or through other media by asking and answering questions about key details and requesting clarification if something is not understood.</span>
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438CF">
+			  </li>
+			  </ul>
+           
+</div>
+</body>

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -3,7 +3,7 @@
     <title>LRMI Example 01</title>
 </head>
 <body>
-<!--html with no schema.org / LRMI mark-up.--> 
+<!--html with schema.org / LRMI mark-up as microdata.--> 
 
 <div itemscope itemtype="http://schema.org/CreativeWork">
     <h1 itemprop="name">Tiles, Blocks, Sapphires &amp; Gold: Designing a Treasure Map</h1>

--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ This repository contains examples of LRMI learning resoursce descriptions.
 
 ##Contents:
 * LRexample01.jsonld - Example of description with many alignments to Common Core State Standards, in JSON LD, from Learning Registry provided by Jason Hoekstra.
-* LRexample01.html - same description as LRexample01.jsonld written as HTML with no schema.org / LRMI mark-up.
+* LRexample01a_md.html - same resource described in LRexample01.jsonld, but simplified and expressed in html with microdata.
+* LRexample01a.json-ld - same description asLRexample01a_md.html but expressed in JSON-LD


### PR DESCRIPTION
We need HTML examples as well as JSON for the schema.org site, so I took the webpage that LRexample01.jsonld refers to along with the JSON and you two had produced, and kind of simplified down from both to create  LRexample01a_md.html.  I ran that through a microdata - JSON conversion and tidied up a bit to get a JSON-LD version of the same. 