### PR TITLE
Update LRexample01a_md.html

### DIFF
--- a/LRexample01a.json-ld
+++ b/LRexample01a.json-ld
@@ -5,23 +5,32 @@
   "@type": "schema:CreativeWork",
   "schema:datePublished": "October 4, 2006",
   "schema:description": "In this activity, students will engage in active problem solving as they create a design for a map leading to a hidden treasure. They will work in collaborative groups, explore numerical problems, and explain the strategies they used to solve design problems.",
+  "schema:learningResourceType" : "teacher"
+  "schema:audience": [
+    {
+      "@type": "EducationalAudience",
+      "educationalRole": "Teacher"
+    }
+  ],
   "schema:educationalAlignment": [
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "Educational level",
       "schema:educationalFramework": "US Grade Levels",
-      "schema:targetName": "PreK"
+      "schema:targetName": "Pre-K"
+      "schema:targetUrl": "http://purl.org/ASN/scheme/ASNEducationLevel/Pre-K"
     },
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "Educational level",
       "schema:educationalFramework": "US Grade Levels",
       "schema:targetName": "1"
+      "schema:targetUrl": "http://purl.org/ASN/scheme/ASNEducationLevel/1"
     },
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "teaches",
-      "schema:educationalFramework": "Common Core State Standards",
+      "schema:educationalFramework": "Common Core State Standards for English Language Arts & Literacy",
       "schema:targetDescription": "Follow agreed-upon rules for discussions (e.g., listening to others and taking turns speaking about the topics and texts under discussion).",
       "schema:targetName": "CCSS.ELA-Literacy.SL.K.1a",
       "schema:targetUrl": [
@@ -36,7 +45,7 @@
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "teaches",
-      "schema:educationalFramework": "Common Core State Standards",
+      "schema:educationalFramework": "Common Core State Standards for English Language Arts & Literacy",
       "schema:targetDescription": "Continue a conversation through multiple exchanges.",
       "schema:targetName": "CCSS.ELA-Literacy.SL.K.1b",
       "schema:targetUrl": [
@@ -51,7 +60,7 @@
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "teaches",
-      "schema:educationalFramework": "Common Core State Standards",
+      "schema:educationalFramework": "Common Core State Standards for English Language Arts & Literacy",
       "schema:targetDescription": "Confirm understanding of a text read aloud or information presented orally or through other media by asking and answering questions about key details and requesting clarification if something is not understood.",
       "schema:targetName": "CCSS.ELA-Literacy.SL.K.2",
       "schema:targetUrl": [

--- a/LRexample01a.json-ld
+++ b/LRexample01a.json-ld
@@ -5,7 +5,7 @@
   "@type": "schema:CreativeWork",
   "schema:datePublished": "October 4, 2006",
   "schema:description": "In this activity, students will engage in active problem solving as they create a design for a map leading to a hidden treasure. They will work in collaborative groups, explore numerical problems, and explain the strategies they used to solve design problems.",
-  "schema:learningResourceType" : "teacher"
+  "schema:learningResourceType" : "teacher",
   "schema:audience": [
     {
       "@type": "EducationalAudience",
@@ -17,14 +17,14 @@
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "Educational level",
       "schema:educationalFramework": "US Grade Levels",
-      "schema:targetName": "Pre-K"
+      "schema:targetName": "Pre-K",
       "schema:targetUrl": "http://purl.org/ASN/scheme/ASNEducationLevel/Pre-K"
     },
     {
       "@type": "schema:AlignmentObject",
       "schema:alignmentType": "Educational level",
       "schema:educationalFramework": "US Grade Levels",
-      "schema:targetName": "1"
+      "schema:targetName": "1",
       "schema:targetUrl": "http://purl.org/ASN/scheme/ASNEducationLevel/1"
     },
     {

--- a/LRexample01a.json-ld
+++ b/LRexample01a.json-ld
@@ -8,8 +8,8 @@
   "schema:learningResourceType" : "teacher",
   "schema:audience": [
     {
-      "@type": "EducationalAudience",
-      "educationalRole": "Teacher"
+      "@type": "schema:EducationalAudience",
+      "schema:educationalRole": "Teacher"
     }
   ],
   "schema:educationalAlignment": [

--- a/LRexample01a_md.html
+++ b/LRexample01a_md.html
@@ -12,12 +12,17 @@
     <h3>Introduction</h3>
     <p itemprop="description">In this activity, students will engage in active problem solving as they create a design for a map leading to a hidden treasure. They will work in collaborative groups, explore numerical problems, and explain the strategies they used to solve design problems.</p>
 
-    <p>This example description is based on <a itemprop="url" href="Based on http://dx.cooperhewitt.org/lessonplan/Tiles-Blocks-Sapphires-Gold-Designing-a-Treasure-Map/" >this page</a></p>
- 
+    <p>This example description is based on <a itemprop="url" href="http://dx.cooperhewitt.org/lessonplan/Tiles-Blocks-Sapphires-Gold-Designing-a-Treasure-Map/" >this page</a></p>
+   <p>A <span itemprop="learningResourceType">lesson plan</span> for <span itemprop="audience" itemscope itemtype="http://schema.org/EducationalAudience"><span itemprop="educationalRole">teacher</span></span>s.</p>
 	   <div itemprop="educationalAlignment" itemscope itemtype="http://schema.org/AlignmentObject">
 	       <meta itemprop="alignmentType" content="Educational level" />
 	       <h3 itemprop="educationalFramework">US Grade Levels</h3>
-	       <p><span itemprop="targetName">PreK-1</span></p>
+	       <p><link itemprop="targetUrl" href="http://purl.org/ASN/scheme/ASNEducationLevel/Pre-K" /><span itemprop="targetName">Pre-K</span></p>
+	   </div>
+	   <div itemprop="educationalAlignment" itemscope itemtype="http://schema.org/AlignmentObject">
+	       <meta itemprop="alignmentType" content="Educational level" />
+	       <h3 itemprop="educationalFramework">US Grade Levels</h3>
+	       <p><link itemprop="targetUrl" href="http://purl.org/ASN/scheme/ASNEducationLevel/1" /><span itemprop="targetName">1</span></p>
 	   </div>
 	   <div class='catfield'>
 	       <h3>Category</h3>
@@ -44,25 +49,24 @@
 			 <ul>
 			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
 			     <meta itemprop="alignmentType" content="teaches" />
-			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/1/a/"><span itemprop="educationalFramework">Common Core State Standards</span></a>:
-			     <span itemprop="targetName">CCSS.ELA-Literacy.SL.K.1a</span><br />
+			     <span itemprop="educationalFramework">Common Core State Standards for English Language Arts & Literacy</span>:
+			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/1/a/"><span itemprop="targetName">CCSS.ELA-Literacy.SL.K.1a</span></a><br />
 			     <span itemprop="targetDescription">Follow agreed-upon rules for discussions (e.g., listening to others and taking turns speaking about the topics and texts under discussion).</span>
-			     
-			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E2">
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E2" />
 			  </li>
 			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
 			     <meta itemprop="alignmentType" content="teaches" />
-			     <span itemprop="educationalFramework">Common Core State Standards</span>:
+			     <span itemprop="educationalFramework">Common Core State Standards for English Language Arts & Literacy</span>:
 			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/1/b/"><span itemprop="targetName">CCSS.ELA-Literacy.SL.K.1b</span></a> <br />
 			     <span itemprop="targetDescription">Continue a conversation through multiple exchanges.</span>			     
-			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E3">
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438E3" />
 			  </li>
 			  <li itemprop="educationalAlignment" itemscope itemType="http://schema.org/AlignmentObject"> 
 			     <meta itemprop="alignmentType" content="teaches" />
-			     <span itemprop="educationalFramework">Common Core State Standards</span>:
+			     <span itemprop="educationalFramework">Common Core State Standards for English Language Arts & Literacy</span>:
 			     <a itemprop="targetUrl" href="http://www.corestandards.org/ELA-Literacy/SL/K/2/"><span itemprop="targetName">CCSS.ELA-Literacy.SL.K.2</span></a> <br />
 			     <span itemprop="targetDescription">Confirm understanding of a text read aloud or information presented orally or through other media by asking and answering questions about key details and requesting clarification if something is not understood.</span>
-			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438CF">
+			     <link itemprop="targetUrl" href="http://purl.org/ASN/resources/S11438CF" />
 			  </li>
 			  </ul>
            


### PR DESCRIPTION
Fixed error in url property / href value for link to original
Split "PreK - 1" into  values of of two separate alignment objects rather than a range
hyphenated Pre-K
added ASN URI for targetUrl of age level alignments
Closed some <link /> elements
Put in full name of CCSS
Moved a link to a specific standard to right place
Added learning resource type
Added educationalRole

